### PR TITLE
split stdout and stderr

### DIFF
--- a/actions/sos
+++ b/actions/sos
@@ -46,8 +46,8 @@ def run_script(script):
     script_dir = os.path.join(archive_dir, script)
     os.makedirs(script_dir)
     os.environ["SOS_SCRIPT_DIR"] = script_dir
-    with open("%s/%s.out" % (script_dir, script), "w") as stdout:
-        with open("%s/%s.err" % (script_dir, script), "w") as stderr:
+    with open(script_dir + "/stdout", "w") as stdout:
+        with open(script_dir + "/stderr", "w") as stderr:
             process = subprocess.Popen(
                 "sos-scripts/" + script,
                 stdout=stdout, stderr=stderr

--- a/actions/sos
+++ b/actions/sos
@@ -9,22 +9,21 @@ from contextlib import contextmanager
 from datetime import datetime
 from charmhelpers.core.hookenv import action_set
 
+archive_dir = None
 log_file = None
 
 @contextmanager
 def archive_dir():
-    """ Open a context with a new temporary directory. This temporary directory
-    is made available to child scripts as the SOS_ARCHIVE_DIR environment var.
+    """ Open a context with a new temporary directory.
 
     When the context closes, the directory is archived, and the archive
     location is added to Juju action output. """
     global log_file
     with tempfile.TemporaryDirectory() as temp_dir:
         name = "sos-" + datetime.now().strftime("%Y%m%d%H%M%S")
-        sos_archive_dir = os.path.join(temp_dir, name)
-        os.makedirs(sos_archive_dir)
-        os.environ["SOS_ARCHIVE_DIR"] = sos_archive_dir
-        with open("%s/sos.log" % sos_archive_dir, "w") as log_file:
+        archive_dir = os.path.join(temp_dir, name)
+        os.makedirs(archive_dir)
+        with open("%s/sos.log" % archive_dir, "w") as log_file:
             yield
         os.chdir(temp_dir)
         tar_path = "/home/ubuntu/%s.tar.gz" % name
@@ -32,26 +31,27 @@ def archive_dir():
             f.add(name)
         action_set({"output": "SOS archive dumped to " + tar_path})
 
-def log(msg, depth=0):
+def log(msg):
     """ Log a message that will be included in the SOS archive.
 
     Must be run inside an archive_dir context. """
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    prefix = "%s | %s" % (timestamp, "| " * depth)
     for line in str(msg).splitlines():
-        log_file.write(prefix + line.rstrip() + "\n")
+        log_file.write(timestamp + " | " + line.rstrip() + "\n")
 
 def run_script(script):
     """ Run a single script. Must be run inside an archive_dir context. """
     log("Running script: " + script)
-    process = subprocess.Popen(
-        "sos-scripts/" + script,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT
-    )
-    for line in process.stdout:
-        log(line.decode("utf-8"), depth=1)
-    exit_code = process.wait()
+    script_dir = os.path.join(archive_dir, script)
+    os.makedirs(script_dir)
+    os.environ["SOS_SCRIPT_DIR"] = script_dir
+    with open("%s/%s.out" % (script_dir, script), "w") as stdout:
+        with open("%s/%s.err" % (script_dir, script), "w") as stderr:
+            process = subprocess.Popen(
+                "sos-scripts/" + script,
+                stdout=stdout, stderr=stderr
+            )
+            exit_code = process.wait()
     if exit_code != 0:
         log("ERROR: %s failed with exit code %d" % (script, exit_code))
 

--- a/actions/sos
+++ b/actions/sos
@@ -13,11 +13,12 @@ archive_dir = None
 log_file = None
 
 @contextmanager
-def archive_dir():
+def archive_context():
     """ Open a context with a new temporary directory.
 
     When the context closes, the directory is archived, and the archive
     location is added to Juju action output. """
+    global archive_dir
     global log_file
     with tempfile.TemporaryDirectory() as temp_dir:
         name = "sos-" + datetime.now().strftime("%Y%m%d%H%M%S")
@@ -34,13 +35,13 @@ def archive_dir():
 def log(msg):
     """ Log a message that will be included in the SOS archive.
 
-    Must be run inside an archive_dir context. """
+    Must be run within archive_context """
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     for line in str(msg).splitlines():
         log_file.write(timestamp + " | " + line.rstrip() + "\n")
 
 def run_script(script):
-    """ Run a single script. Must be run inside an archive_dir context. """
+    """ Run a single script. Must be run within archive_context """
     log("Running script: " + script)
     script_dir = os.path.join(archive_dir, script)
     os.makedirs(script_dir)
@@ -59,7 +60,7 @@ def run_all_scripts():
     """ Run all scripts. For the sake of robustness, log and ignore any
     exceptions that occur.
 
-    Must be run inside an archive_dir context. """
+    Must be run within archive_context """
     scripts = os.listdir("sos-scripts")
     for script in scripts:
         try:
@@ -77,7 +78,7 @@ def add_lib_folder_to_python_path():
 def main():
     """ Open an archive context and run all scripts. """
     add_lib_folder_to_python_path()
-    with archive_dir():
+    with archive_context():
         run_all_scripts()
 
 if __name__ == "__main__":

--- a/lib/sos_script.py
+++ b/lib/sos_script.py
@@ -1,7 +1,7 @@
 import os
 
-dir = os.environ["SOS_ARCHIVE_DIR"]
+dir = os.environ["SOS_SCRIPT_DIR"]
 
 def open_file(path, *args, **kwargs):
-  """ Open a file within the SOS archive """
+  """ Open a file within the SOS script dir """
   return open(os.path.join(dir, path), *args, **kwargs)

--- a/sos-scripts/charm-unitdata
+++ b/sos-scripts/charm-unitdata
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 
-import sos_archive
+import sos_script
 import json
 from charmhelpers.core import unitdata
 
 kv = unitdata.kv()
 data = kv.getrange("")
 
-with sos_archive.open_file("unitdata.json", "w") as f:
+with sos_script.open_file("unitdata.json", "w") as f:
   json.dump(data, f, indent=2)
   f.write("\n")

--- a/sos-scripts/juju-logs
+++ b/sos-scripts/juju-logs
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eu
 
-cp /var/log/juju/* $SOS_ARCHIVE_DIR
+cp /var/log/juju/* $SOS_SCRIPT_DIR

--- a/sos-scripts/systemctl
+++ b/sos-scripts/systemctl
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-systemctl > $SOS_ARCHIVE_DIR/systemctl
-journalctl > $SOS_ARCHIVE_DIR/journalctl
+systemctl > $SOS_SCRIPT_DIR/systemctl
+journalctl > $SOS_SCRIPT_DIR/journalctl


### PR DESCRIPTION
@wwwtyro review plz

Resulting directory layout within tar file:

```
$ tar -xf sos-20161108204835.tar.gz 
$ tree sos-20161108204835 
sos-20161108204835
├── charm-unitdata
│   ├── stderr
│   ├── stdout
│   └── unitdata.json
├── juju-logs
│   ├── machine-0.log
│   ├── stderr
│   ├── stdout
│   └── unit-sos-test-0.log
├── sos.log
├── systemctl
│   ├── journalctl
│   ├── stderr
│   ├── stdout
│   └── systemctl
└── test
    ├── stderr
    └── stdout

4 directories, 14 files
```