### PR TITLE
Remove `systemd-analyze plot` from debug scripts

### DIFF
--- a/debug-scripts/systemd
+++ b/debug-scripts/systemd
@@ -6,5 +6,4 @@ journalctl > $DEBUG_SCRIPT_DIR/journalctl
 systemd-analyze time > $DEBUG_SCRIPT_DIR/systemd-analyze-time
 systemd-analyze blame > $DEBUG_SCRIPT_DIR/systemd-analyze-blame
 systemd-analyze critical-chain > $DEBUG_SCRIPT_DIR/systemd-analyze-critical-chain
-systemd-analyze plot > $DEBUG_SCRIPT_DIR/systemd-analyze-plot.svg
 systemd-analyze dump > $DEBUG_SCRIPT_DIR/systemd-analyze-dump


### PR DESCRIPTION
I just got a 633 MB debug archive containing a 9 GB systemd-analyze-plot.svg in it.

I don't really see the value in having this plot. Let's remove it.